### PR TITLE
Find posts from tags

### DIFF
--- a/src/BearNote.php
+++ b/src/BearNote.php
@@ -16,6 +16,22 @@ class BearNote extends Model
         return static::where('title', 'like', '%'.$query.'%')->get();
     }
 
+    public static function fromTag($tag)
+    {
+        return static::fromTags([$tag]);
+    }
+
+    public static function fromTags(array $tags)
+    {
+        return static::whereExists(function ($query) use ($tags) {
+            $query->selectRaw(1)
+                ->from('Z_7TAGS')
+                ->join('ZSFNOTETAG', 'ZSFNOTETAG.Z_PK', '=', 'Z_7TAGS.Z_14TAGS')
+                ->whereRaw('Z_7TAGS.Z_7NOTES = id')
+                ->whereIn('ZSFNOTETAG.ZTITLE', $tags);
+        })->get();
+    }
+
     public function getContentAndStoreImages($callback)
     {
         // Check the note's content for images:


### PR DESCRIPTION
First and foremost, great work on this package. I write all of my blog posts in Bear Notes and then copy/paste them into Nova and, frankly, that process is a pita. I see this being a huge timesaver and can even see me building a Nova tool on top of it.

I organise all of my posts with tags so, for me, It would be great if I can find all posts from a specific tag and run a command to sync them all. This PR facilitates that.

Let me know what you think!

Thanks,
Joe