### PR TITLE
Implement note tag pivot resolver

### DIFF
--- a/src/BearNote.php
+++ b/src/BearNote.php
@@ -7,13 +7,18 @@ use Illuminate\Database\Eloquent\Model;
 
 class BearNote extends Model
 {
-    use UsesBearsDatabaseConnection;
+    use UsesBearsDatabaseConnection, ResolvesNoteTagPivot;
 
     protected $appends = ['content'];
 
     public function tags()
     {
-        return $this->belongsToMany(BearTag::class, 'Z_6TAGS', 'Z_6NOTES', 'Z_13TAGS');
+        return $this->belongsToMany(
+            BearTag::class,
+            $this->getNoteTagPivotTable(),
+            $this->getNoteColumn(),
+            $this->getTagColumn()
+        );
     }
 
     public static function searchByTitle($query)
@@ -59,7 +64,7 @@ class BearNote extends Model
         parent::boot();
 
         static::addGlobalScope(function ($builder) {
-            $builder->fromRaw("(select Z_PK as id, ZTITLE as title, ZTEXT as raw_content from ZSFNOTE) as bear_notes");
+            $builder->fromRaw("(select Z_PK as id, ZTITLE as title, ZTEXT as raw_content, Z_ENT as pivot_column_id from ZSFNOTE) as bear_notes");
         });
     }
 }

--- a/src/BearTag.php
+++ b/src/BearTag.php
@@ -6,8 +6,8 @@ use Illuminate\Database\Eloquent\Model;
 
 class BearTag extends Model
 {
-    use UsesBearsDatabaseConnection;
-
+    use UsesBearsDatabaseConnection, ResolvesNoteTagPivot;
+    
     public static function searchByTitle($query)
     {
         return static::where('title', 'like', '%'.$query.'%')->get();
@@ -15,7 +15,12 @@ class BearTag extends Model
 
     public function notes()
     {
-        return $this->belongsToMany(BearNote::class, 'Z_6TAGS', 'Z_13TAGS', 'Z_6NOTES');
+        return $this->belongsToMany(
+            BearNote::class,
+            $this->getNoteTagPivotTable(),
+            $this->getTagColumn(),
+            $this->getNoteColumn()
+        );
     }
 
     protected static function boot()
@@ -23,7 +28,7 @@ class BearTag extends Model
         parent::boot();
 
         static::addGlobalScope(function ($builder) {
-            $builder->fromRaw("(select Z_PK as id, ZTITLE as title from ZSFNOTETAG) as bear_tags");
+            $builder->fromRaw("(select Z_PK as id, ZTITLE as title, Z_ENT as pivot_column_id from ZSFNOTETAG) as bear_tags");
         });
     }
 }

--- a/src/ResolvesNoteTagPivot.php
+++ b/src/ResolvesNoteTagPivot.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace BearSync;
+
+trait ResolvesNoteTagPivot
+{
+    public function getNotePivotColumnIdAttribute()
+    {
+        return BearNote::pivotColumnId();
+    }
+    
+    public function getTagPivotColumnIdAttribute()
+    {
+        return BearTag::pivotColumnId();
+    }
+
+    protected function getNoteTagPivotTable()
+    {
+        return "Z_{$this->notePivotColumnId}TAGS";
+    }
+
+    protected function getTagColumn()
+    {
+        return "Z_{$this->tagPivotColumnId}TAGS";
+    }
+
+    protected function getNoteColumn()
+    {
+        return "Z_{$this->notePivotColumnId}NOTES";
+    }
+
+    public function scopePivotColumnId($query)
+    {
+        return $query->distinct()
+            ->select('pivot_column_id')
+            ->first()
+            ->pivot_column_id;
+    }
+}


### PR DESCRIPTION
OK so full disclosure - I can't be sure this will resolve the problem. It appears that Bear rename tables and relations between versions and this PR aims to fix this dynamically.

To do this, I grab the values of `Z_ENT` from the notes and tags tables which seems to be some sort of reference to the version. **However, that is a big assumption**. I then use this value to dynamically set the table and column names of the relationship.

Possibly resolves #4  